### PR TITLE
readme: relative hyperlink - setnick: escaped prefix

### DIFF
--- a/Information/README.md
+++ b/Information/README.md
@@ -2,7 +2,7 @@
 Commands that show information about certain components in Discord.
 
 ### Commands
-• [User Info](https://github.com/Max-Alimghty/Information/userinfo.yag)
+• [User Info](./userinfo.yag)
 
 ### Work In Progress
 Emoji Info

--- a/Moderation/setnick.yag
+++ b/Moderation/setnick.yag
@@ -16,7 +16,7 @@
 {{- end}}
 
 {{/* The command */}}
-{{if reFind (print "(?i)\A" $prefix "set-?nick") .Message.Content}}
+{{if reFind (print `(?i)\A\Q` $prefix `\Eset-?nick`) .Message.Content}}
     {{if $whitelist}}
         {{if ge (len .CmdArgs) 2}}
             {{with reFind `\d{17,19}` (index .CmdArgs 0)}}


### PR DESCRIPTION
Changed the link to [userinfo.yag](/Max-Almighty/yagpdb-cc/tree/main/Information/README.md) to a relative link (`./userinfo.yag`)
Added `\Q` and `\E` to prefix regex to avoid errors when prefix includes special characters
Small syntax error, using single blackslash with double quotes, replaced with backticks